### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Tavily MCP server provides:
 - Real-time web search capabilities through the tavily-search tool
 - Intelligent data extraction from web pages via the tavily-extract tool
 
+<a href="https://glama.ai/mcp/servers/jog9una8ox"><img width="380" height="200" src="https://glama.ai/mcp/servers/jog9una8ox/badge" alt="Tavily Server MCP server" /></a>
 
 ## Prerequisites 🔧
 


### PR DESCRIPTION
This PR adds a badge for the [Tavily MCP Server](https://glama.ai/mcp/servers/jog9una8ox) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jog9una8ox"><img width="380" height="200" src="https://glama.ai/mcp/servers/jog9una8ox/badge" alt="Tavily Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.