### PR TITLE
correct tavily-mcp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Before you begin, ensure you have:
 ### Running with NPX 
 
 ```bash
-npx -y tavily-mcp@0.2.1  
+npx -y tavily-mcp@0.2.0  
 ```
 
 ### Installing via Smithery


### PR DESCRIPTION
The latest version of tavily-mcp in npm is v0.2.0, but the command in readme used an not exist version v0.2.1;

https://www.npmjs.com/package/tavily-mcp?activeTab=versions