### PR TITLE
feat: add MCP tool annotations for all 4 tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,9 @@ class TavilyClient {
               }
             },
             required: ["query"]
+          },
+          annotations: {
+            readOnlyHint: true
           }
         },
         {
@@ -280,6 +283,9 @@ class TavilyClient {
               },
             },
             required: ["urls"]
+          },
+          annotations: {
+            readOnlyHint: true
           }
         },
         {
@@ -350,6 +356,9 @@ class TavilyClient {
               },
             },
             required: ["url"]
+          },
+          annotations: {
+            readOnlyHint: true
           }
         },
         {
@@ -403,6 +412,9 @@ class TavilyClient {
               }
             },
             required: ["url"]
+          },
+          annotations: {
+            readOnlyHint: true
           }
         },
       ];


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`) to all 4 tools to help LLMs understand tool behavior and enable clients to auto-approve safe operations.

## Changes

- Added `readOnlyHint: true` to all 4 tools:
  - `tavily-search` - Web search (read-only)
  - `tavily-extract` - Content extraction (read-only)
  - `tavily-crawl` - Web crawling (read-only)
  - `tavily-map` - Site mapping (read-only)

## Why This Matters

Tool annotations are part of the MCP specification that enable:
- Clients to auto-approve safe (read-only) operations
- Better tool discovery and filtering
- Improved LLM decision-making about tool usage

## Testing

- [x] Server builds successfully (`npm run build`)
- [x] Annotation values match actual tool behavior (all read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks all tools as read-only to improve client auto-approval and tool usage signaling per MCP spec.
> 
> - Added `annotations: { readOnlyHint: true }` to `tavily-search`, `tavily-extract`, `tavily-crawl`, and `tavily-map` definitions in `src/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06aed30496c0a7887994eb8e137dc75d84b01083. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->