### PR TITLE
feat: add support for Gemini CLI via gemini extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ You will then be redirected to your `mcp.json` file where you have to add `your-
 }
 ```
 
+## Connect to Gemini CLI
+
+Run the following command in your terminal to install Tavily MCP server on Gemini CLI:
+
+```bash
+gemini extensions install https://github.com/tavily-ai/tavily-mcp
+```
+
 ### Remote MCP Server OAuth Flow
 
 The Tavily Remote MCP server supports secure OAuth authentication, allowing you to connect and authorize seamlessly with compatible clients.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,16 @@
+{
+    "name": "tavily-mcp",
+    "version": "1.0.0",
+    "mcpServers": {
+        "tavily-mcp": {
+            "httpUrl": "https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}"
+        }
+    },
+    "settings": [
+        {
+            "name": "Tavily API Key",
+            "description": "Tavily API Key",
+            "envVar": "TAVILY_API_KEY"
+        }
+    ]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs + new extension manifest only; no runtime logic changes or security-sensitive code paths modified.
> 
> **Overview**
> Adds **Gemini CLI** installation support by documenting the `gemini extensions install` command in `README.md`.
> 
> Introduces a new `gemini-extension.json` manifest that configures the Tavily MCP server URL and exposes `TAVILY_API_KEY` as a required environment setting for Gemini extensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fce8f4ac82f4da829807d530e4a4ee1483d9d50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->