### PR TITLE
fix: bump hono to resolve timing comparison vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- Bumps `hono` from 4.11.7 to 4.12.2 in `package-lock.json` to resolve [GHSA-gq3j-xvxp-8hrf](https://github.com/advisories/GHSA-gq3j-xvxp-8hrf)
- hono < 4.11.10 lacks timing-safe comparison in `basicAuth` and `bearerAuth` middleware, which could allow timing attacks to leak authentication tokens
- Lockfile-only change — `hono` is a transitive dependency via `@modelcontextprotocol/sdk`

## Test plan

- [x] `npm audit` returns 0 vulnerabilities
- [ ] Verify MCP server starts and responds to tool calls as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no runtime code changes in this repo; primary risk is minor upstream behavior/regression from the new `hono` patch version.
> 
> **Overview**
> Updates the lockfile to bump transitive dependency `hono` from `4.11.7` to `4.12.2` (via `@modelcontextprotocol/sdk`), updating the resolved tarball and integrity hash.
> 
> No application/source changes; this is a dependency-only update intended to pick up upstream security fixes (e.g., timing-safe comparisons in auth middleware).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89981729f9957ceb955dcc1c2b4655d9a329d95e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->