### PR TITLE
feat: add 'news' and 'finance' to search topic enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,8 +164,8 @@ class TavilyClient {
               },
               topic : {
                 type: "string",
-                enum: ["general"],
-                description: "The category of the search. This will determine which of our agents will be used for the search",
+                enum: ["general", "news", "finance"],
+                description: "The category of the search. This will determine which of our agents will be used for the search. 'general' is for broader, general-purpose searches. 'news' is useful for retrieving real-time updates, particularly about politics, sports, and major current events covered by mainstream media sources. 'finance' is for financial data and market information.",
                 default: "general"
               },
               time_range: {


### PR DESCRIPTION
The topic parameter in the tavily_search tool schema was hardcoded to only allow 'general', but the Tavily API supports 'general', 'news', and 'finance' topics.

- Add 'news' and 'finance' to the topic enum in the tool input schema
- Update the description to explain what each topic category is for

Ref: https://docs.tavily.com/documentation/api-reference/endpoint/search#body-topic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that expands accepted `topic` values for `tavily_search`; it doesn’t alter request execution logic beyond allowing additional inputs.
> 
> **Overview**
> Updates the `tavily_search` tool input schema to allow `topic` values `news` and `finance` in addition to `general`.
> 
> Expands the `topic` field description to clarify intended usage for each category so clients can select the appropriate search mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91b4d3150e6ab06463239c60327e6cd019bc2949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->