### PR TITLE
fix: prevent DEFAULT_PARAMETERS from overriding user-provided values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -587,8 +587,8 @@ class TavilyClient {
         include_images: params.include_images,
         include_image_descriptions: params.include_image_descriptions,
         include_raw_content: params.include_raw_content,
-        include_domains: params.include_domains || [],
-        exclude_domains: params.exclude_domains || [],
+        include_domains: params.include_domains,
+        exclude_domains: params.exclude_domains,
         country: params.country,
         include_favicon: params.include_favicon,
         start_date: params.start_date,
@@ -602,6 +602,10 @@ class TavilyClient {
           searchParams[key] = defaults[key];
         }
       }
+
+      // Ensure array fields are never undefined (API expects arrays)
+      searchParams.include_domains = searchParams.include_domains ?? [];
+      searchParams.exclude_domains = searchParams.exclude_domains ?? [];
       
       // We have to set defaults due to the issue with optional parameter types or defaults = None
       // Because of this, we have to set the time_range to None if start_date or end_date is set

--- a/src/index.ts
+++ b/src/index.ts
@@ -596,9 +596,9 @@ class TavilyClient {
         api_key: API_KEY,
       };
       
-      // Apply default parameters
-      for (const key in searchParams) {
-        if (key in defaults) {
+      // Apply default parameters only for keys not explicitly provided by the user
+      for (const key in defaults) {
+        if (key in searchParams && (searchParams[key] === undefined || searchParams[key] === null)) {
           searchParams[key] = defaults[key];
         }
       }


### PR DESCRIPTION
## Summary

Fixes #127

The default parameter application loop iterated over `searchParams` keys and unconditionally replaced matching values from `defaults`. This caused user-provided values to be silently overwritten by DEFAULT_PARAMETERS.

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Reverse loop direction: iterate `defaults` keys, only apply when user value is undefined/null |

## Before / After

**Before** (buggy):
```typescript
for (const key in searchParams) {       // iterates user params
  if (key in defaults) {
    searchParams[key] = defaults[key];  // always overwrites
  }
}
```

**After** (fixed):
```typescript
for (const key in defaults) {           // iterates defaults
  if (key in searchParams && (searchParams[key] === undefined || searchParams[key] === null)) {
    searchParams[key] = defaults[key];  // only fills gaps
  }
}
```

## Test Plan

- [x] `npx tsc --noEmit` — zero errors
- [ ] With `DEFAULT_PARAMETERS='{"max_results":5}'`, calling `tavily_search(query="test", max_results=10)` should return 10 results (not 5)
- [ ] With `DEFAULT_PARAMETERS='{"search_depth":"basic"}'`, calling `tavily_search(query="test")` should use "basic" (default fills the gap)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to `tavily_search` request parameter merging and should only affect how defaults are applied; main risk is subtle behavior changes for callers relying on old (buggy) overriding behavior.
> 
> **Overview**
> Fixes `tavily_search` parameter merging so `DEFAULT_PARAMETERS` no longer overwrites explicitly provided user arguments; defaults are now applied only when the user value is `undefined`/`null`.
> 
> Also normalizes `include_domains`/`exclude_domains` so they are never `undefined` (coalesced to `[]`) to match the Tavily API’s expected array types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7b2a3aea45c717af8236207671f24f0bb931ea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*