### PR TITLE
feat: add progress notifications for all tools via MCP progressToken

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,7 @@ class TavilyClient {
             break;
 
           case "tavily_crawl":
-            await this.reportProgress(progressToken, `Crawling the url: ${args.url} for relevant informatioin`);
+            await this.reportProgress(progressToken, `Crawling the url: ${args.url} for relevant information`);
             const crawlResponse = await this.crawl({
               url: args.url,
               max_depth: args.max_depth,
@@ -518,6 +518,7 @@ class TavilyClient {
             };
 
           case "tavily_map":
+            await this.reportProgress(progressToken, `Mapping the structure of the site: ${args.url}`);
             const mapResponse = await this.map({
               url: args.url,
               max_depth: args.max_depth,


### PR DESCRIPTION
## Summary

Adds real-time progress notifications for all tools using the MCP 
`notifications/progress` protocol, allowing clients to display live 
status updates during tool execution.

## Changes

- Added `reportProgress()` helper that sends `notifications/progress` 
  notifications when a `progressToken` is present in `request.params._meta`
- Wired progress messages into all five tools: `tavily_search`, 
  `tavily_extract`, `tavily_crawl`, `tavily_map`, and `tavily_research`
- Gracefully no-ops when no `progressToken` is provided, so clients that 
  don't send one are unaffected

## Motivation

Clients like Claude Desktop and other MCP-compatible hosts support 
progress callbacks but had no visibility into tool execution status. 
This is especially impactful for `tavily_research`, which can run for 
up to 15 minutes. Users now see live poll updates instead of a silent 
wait.

## Equivalent to

Python FastMCP's `context.report_progress()` — same concept, now 
available for the JS server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional MCP `notifications/progress` emissions gated on `_meta.progressToken`, without changing Tavily API request/response handling. Main risk is minor client-side noise or incompatibility if hosts mishandle progress notifications.
> 
> **Overview**
> Adds a `reportProgress(progressToken, message)` helper that sends MCP `notifications/progress` and no-ops when no token is provided.
> 
> Updates `CallToolRequestSchema` handling to read `request.params._meta?.progressToken` and emit pre-execution status messages for `tavily_search`, `tavily_extract`, `tavily_crawl`, and `tavily_research`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d35a735c7db10a37a76456d5ddfd5433829271c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->