### PR TITLE
docs(readme): quote URLs in shell commands for zsh compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Authorization: Bearer <your-api-key>
 Pass your API key directly in the URL. Replace `<your-api-key>` with your actual [Tavily API key](https://www.tavily.com/):
 
 ```bash
-claude mcp add --transport http tavily https://mcp.tavily.com/mcp/?tavilyApiKey=<your-api-key>
+claude mcp add --transport http tavily 'https://mcp.tavily.com/mcp/?tavilyApiKey=<your-api-key>'
 ```
 
 #### Option 2: OAuth Authentication Flow
@@ -66,7 +66,7 @@ After adding, you'll need to complete the authentication flow:
 **Tip:** Add `--scope user` to either command to make the Tavily MCP server available globally across all your projects:
 
 ```bash
-claude mcp add --transport http --scope user tavily https://mcp.tavily.com/mcp/?tavilyApiKey=<your-api-key>
+claude mcp add --transport http --scope user tavily 'https://mcp.tavily.com/mcp/?tavilyApiKey=<your-api-key>'
 ```
 
 Once configured, you'll have access to the Tavily search, extract, map, and crawl tools.


### PR DESCRIPTION
Fixes #112

On zsh (the default shell on macOS since Catalina), the ? character in
URLs is treated as a glob pattern. When no files match, zsh throws
"no matches found" before the command can execute.

This affects the two claude mcp add commands in the README that include
?tavilyApiKey= in the URL. Wrapping them in single quotes prevents
glob expansion on both zsh and bash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts README shell command examples to avoid zsh glob expansion on `?` in URLs.
> 
> **Overview**
> Updates the README’s Claude Code setup examples to wrap the `https://mcp.tavily.com/mcp/?tavilyApiKey=...` URL in single quotes, preventing zsh from treating `?` as a glob and failing before the command runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d4114631c8c957dddde04f16d8381e96abf4f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->