### PR TITLE
fix: return isError instead of throwing McpError for missing API key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -437,12 +437,16 @@ class TavilyClient {
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
-      // Check for API key at request time and return proper JSON-RPC error
+      // Return a graceful isError response when the API key is missing,
+      // so agents can self-correct instead of seeing a server crash.
       if (!API_KEY) {
-        throw new McpError(
-          ErrorCode.InvalidRequest,
-          "TAVILY_API_KEY environment variable is required. Please set it before using this MCP server."
-        );
+        return {
+          content: [{
+            type: "text",
+            text: "TAVILY_API_KEY environment variable is required. Please set it before using this MCP server."
+          }],
+          isError: true,
+        };
       }
 
       try {


### PR DESCRIPTION
## Summary

Fixes #161. When `TAVILY_API_KEY` is not set, the `CallToolRequestSchema` handler throws `McpError(ErrorCode.InvalidRequest, ...)`, which produces a JSON-RPC error frame. MCP clients treat this as a server crash rather than a recoverable failure.

## Fix

Replace the `throw new McpError(...)` with a return of `{ content: [...], isError: true }`. This lets agents read the error message and self-correct (e.g., prompt the user to set the key) instead of seeing an opaque server crash.

This matches the existing error handling pattern already used for Axios API errors at lines 554-573 in the same file.

## Before

```
JSON-RPC error: {"code": -32600, "message": "TAVILY_API_KEY environment variable is required..."}
```

Agents see a server crash. No recovery path.

## After

```json
{
  "content": [{"type": "text", "text": "TAVILY_API_KEY environment variable is required..."}],
  "isError": true
}
```

Agents see a tool error with a clear message. Can retry or ask the user.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to request handler error handling that only affects behavior when `TAVILY_API_KEY` is unset.
> 
> **Overview**
> Prevents MCP clients from treating a missing `TAVILY_API_KEY` as a server crash by replacing the thrown `McpError(ErrorCode.InvalidRequest, ...)` in the `CallToolRequestSchema` handler with a normal tool response containing `content` and `isError: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586a808b3565b04a26dd730a6147121e4df43ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->