### PR TITLE
Fix tavily-mcp version metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "test": "npm run build && node --test tests/cli-metadata.test.mjs",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {CallToolRequestSchema, ListToolsRequestSchema, Tool} from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
+import fs from "fs";
+import path from "path";
 import { randomUUID } from "crypto";
 import dotenv from "dotenv";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
@@ -17,6 +19,25 @@ const IS_KEYLESS = !API_KEY;
 const HUMAN_ID = process.env.TAVILY_HUMAN_ID;
 const SESSION_ID = randomUUID();
 
+function readPackageVersion(): string {
+  const entrypoint = process.argv[1] ? fs.realpathSync(process.argv[1]) : process.cwd();
+  let dir = path.dirname(path.resolve(entrypoint));
+  for (let i = 0; i < 5; i++) {
+    const packagePath = path.join(dir, "package.json");
+    if (fs.existsSync(packagePath)) {
+      const packageJSON = JSON.parse(fs.readFileSync(packagePath, "utf8")) as { version?: unknown };
+      if (typeof packageJSON.version === "string") return packageJSON.version;
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return "unknown";
+}
+
+const PACKAGE_VERSION = readPackageVersion();
 
 interface TavilyResponse {
   // Response structure from Tavily API
@@ -85,7 +106,7 @@ class TavilyClient {
     this.server = new Server(
       {
         name: "tavily-mcp",
-        version: "0.2.20",
+        version: PACKAGE_VERSION,
       },
       {
         capabilities: {
@@ -898,6 +919,7 @@ interface Arguments {
 
 // Modify the command line parsing section to use proper typing
 const argv = yargs(hideBin(process.argv))
+  .version(PACKAGE_VERSION)
   .option('list-tools', {
     type: 'boolean',
     description: 'List all available tools and exit',

--- a/tests/cli-metadata.test.mjs
+++ b/tests/cli-metadata.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+const packDir = await mkdtemp(path.join(os.tmpdir(), 'tavily-mcp-pack-'));
+const packResult = await execFileAsync('npm', ['pack', '--pack-destination', packDir], { cwd: root });
+const tarballName = packResult.stdout
+  .trim()
+  .split('\n')
+  .find((line) => line.endsWith('.tgz'));
+assert.ok(tarballName, 'npm pack did not print a tarball path');
+const tarball = path.join(packDir, tarballName);
+const npmEnv = { ...process.env };
+delete npmEnv.npm_config_npm_globalconfig;
+delete npmEnv.npm_config_verify_deps_before_run;
+delete npmEnv.npm_config__jsr_registry;
+
+test.after(async () => {
+  await rm(packDir, { recursive: true, force: true });
+});
+
+async function runTavilyMcp(args) {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'npm',
+      ['exec', '--yes', `--package=${tarball}`, '--', 'tavily-mcp', ...args],
+      { cwd: path.dirname(packDir), env: npmEnv }
+    );
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    return {
+      code: error.code,
+      stdout: error.stdout ?? '',
+      stderr: error.stderr ?? ''
+    };
+  }
+}
+
+test('top-level version flag prints the package version', async () => {
+  const result = await runTavilyMcp(['--version']);
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout.trim(), pkg.version);
+});
+
+test('top-level help remains successful', async () => {
+  const result = await runTavilyMcp(['--help']);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /List all available tools and exit/);
+});


### PR DESCRIPTION
## Summary
- make tavily-mcp --version print the installed package version
- reuse the same package version for MCP server metadata
- add a packed-tarball metadata test that runs through npm exec

## Reproduction
`npm exec --yes --package=tavily-mcp@0.2.20 -- tavily-mcp --version` currently prints `unknown`.

## Root cause
The published bin runs through npm's .bin symlink path and yargs cannot infer the package version in that installed-package execution path. The new helper resolves the real entrypoint path, walks up to the installed package.json, and binds that version explicitly.

## Validation
- Red test first: packed tarball test failed with `unknown !== 0.2.20`
- `npm test`
- local `npm pack` + `npm exec --package=<tarball> -- tavily-mcp --version` prints `0.2.20`
- local `npm pack` + `npm exec --package=<tarball> -- tavily-mcp --help`
- `git diff --check`