### PR TITLE
Add server `instructions` + clarify tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Tavily MCP server provides five tools for web search and research:
 **When to use `tavily_search` vs `tavily_research`:** Use `tavily_search` for quick lookups where a snippet-level answer is enough. Use `tavily_research` when you need a thorough, synthesized answer drawn from multiple sources — it is slower and costs more credits (up to 250 per call), but returns a detailed report rather than a list of results.
 
 
-### 📚 Helpful Resources
+### Helpful Resources
 - [Tutorial](https://medium.com/@dustin_36183/building-a-knowledge-graph-assistant-combining-tavily-and-neo4j-mcp-servers-with-claude-db92de075df9) on combining Tavily MCP with Neo4j MCP server
 - [Tutorial](https://medium.com/@dustin_36183/connect-your-coding-assistant-to-the-web-integrating-tavily-mcp-with-cline-in-vs-code-5f923a4983d1) on integrating Tavily MCP with Cline in VS Code
 
@@ -79,7 +79,7 @@ Once configured, you'll have access to all five Tavily tools: search, research, 
 ## Connect to Cursor
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tavily-remote-mcp&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9tY3AudGF2aWx5LmNvbS9tY3AvP3RhdmlseUFwaUtleT08eW91ci1hcGkta2V5PiIsImVudiI6e319)
 
-Click the ⬆️ Add to Cursor ⬆️ button, this will do most of the work for you but you will still need to edit the configuration to add your API-KEY. You can get a Tavily API key [here](https://www.tavily.com/).
+Click the Add to Cursor button, this will do most of the work for you but you will still need to edit the configuration to add your API-KEY. You can get a Tavily API key [here](https://www.tavily.com/).
 
 
 once you click the button you should be redirect to Cursor ...
@@ -162,7 +162,7 @@ After successful OAuth authentication, you can control which API key is used by 
 
 ## Local MCP 
 
-### Prerequisites 🔧
+### Prerequisites
 
 Before you begin, ensure you have:
 
@@ -185,34 +185,7 @@ Before you begin, ensure you have:
 npx -y tavily-mcp@latest 
 ```
 
-## tavily_research — Deep Research Tool 🔬
-
-The `tavily_research` tool performs comprehensive, multi-source research and returns a synthesized answer rather than a list of search results. Use it when a question requires gathering and reconciling information from many sources.
-
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `input` | `string` | ✅ | A comprehensive description of the research task |
-| `model` | `string` | ❌ | Research depth — `"mini"` for narrow tasks with few subtopics, `"pro"` for broad tasks with many subtopics, `"auto"` (default) to let Tavily pick |
-
-### Example
-
-```json
-{
-  "input": "What are the key differences between transformer and state space model architectures for long-context tasks?",
-  "model": "pro"
-}
-```
-
-### Notes
-
-- **Rate limit:** 20 requests per minute
-- **Credit cost:** Up to 250 credits per call (vs. 1–5 for `tavily_search`)
-- **Response format:** A detailed synthesized report with citations, not a list of snippets
-- **Streaming/async:** The remote MCP endpoint handles polling internally — the tool call blocks until the report is ready
-
-## Default Parameters Configuration ⚙️
+## Default Parameters Configuration
 
 You can set default parameter values for the `tavily-search` tool using the `DEFAULT_PARAMETERS` environment variable. This allows you to configure default search behavior without specifying these parameters in every request.
 
@@ -261,7 +234,7 @@ This is **entirely optional** — leave it unset and behavior is unchanged.
 
 **Privacy note:** Tavily hashes `human_id` server-side (SHA-256) before storage, so the raw value is never persisted. Even so, prefer opaque identifiers (e.g. an internal user ID) over raw PII like emails when possible.
 
-## Acknowledgments ✨
+## Acknowledgments
 
 - [Model Context Protocol](https://modelcontextprotocol.io) for the MCP specification
 - [Anthropic](https://anthropic.com) for Claude Desktop

--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 ![npm](https://img.shields.io/npm/dt/tavily-mcp)
 ![smithery badge](https://smithery.ai/badge/@tavily-ai/tavily-mcp)
 
-The Tavily MCP server provides:
-- search, extract, map, crawl tools
-- Real-time web search capabilities through the tavily-search tool
-- Intelligent data extraction from web pages via the tavily-extract tool
-- Powerful web mapping tool that creates a structured map of website 
-- Web crawler that systematically explores websites 
+The Tavily MCP server provides five tools for web search and research:
+
+| Tool | Description |
+|------|-------------|
+| `tavily_search` | Fast web search — returns ranked snippets and URLs for a query |
+| `tavily_research` | Deep multi-source research — synthesizes findings from many sources into a comprehensive answer |
+| `tavily_extract` | Extract full content from specific URLs |
+| `tavily_map` | Map a website's URL structure |
+| `tavily_crawl` | Bulk-crawl many pages from a site |
+
+**When to use `tavily_search` vs `tavily_research`:** Use `tavily_search` for quick lookups where a snippet-level answer is enough. Use `tavily_research` when you need a thorough, synthesized answer drawn from multiple sources — it is slower and costs more credits (up to 250 per call), but returns a detailed report rather than a list of results.
 
 
 ### 📚 Helpful Resources
@@ -69,7 +74,7 @@ After adding, you'll need to complete the authentication flow:
 claude mcp add --transport http --scope user tavily https://mcp.tavily.com/mcp/?tavilyApiKey=<your-api-key>
 ```
 
-Once configured, you'll have access to the Tavily search, extract, map, and crawl tools.
+Once configured, you'll have access to all five Tavily tools: search, research, extract, map, and crawl.
 
 ## Connect to Cursor
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tavily-remote-mcp&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9tY3AudGF2aWx5LmNvbS9tY3AvP3RhdmlseUFwaUtleT08eW91ci1hcGkta2V5PiIsImVudiI6e319)
@@ -179,6 +184,33 @@ Before you begin, ensure you have:
 ```bash
 npx -y tavily-mcp@latest 
 ```
+
+## tavily_research — Deep Research Tool 🔬
+
+The `tavily_research` tool performs comprehensive, multi-source research and returns a synthesized answer rather than a list of search results. Use it when a question requires gathering and reconciling information from many sources.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `input` | `string` | ✅ | A comprehensive description of the research task |
+| `model` | `string` | ❌ | Research depth — `"mini"` for narrow tasks with few subtopics, `"pro"` for broad tasks with many subtopics, `"auto"` (default) to let Tavily pick |
+
+### Example
+
+```json
+{
+  "input": "What are the key differences between transformer and state space model architectures for long-context tasks?",
+  "model": "pro"
+}
+```
+
+### Notes
+
+- **Rate limit:** 20 requests per minute
+- **Credit cost:** Up to 250 credits per call (vs. 1–5 for `tavily_search`)
+- **Response format:** A detailed synthesized report with citations, not a list of snippets
+- **Streaming/async:** The remote MCP endpoint handles polling internally — the tool call blocks until the report is ready
 
 ## Default Parameters Configuration ⚙️
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,23 @@ class TavilyClient {
         capabilities: {
           tools: {},
         },
+        instructions: `Tavily provides five web tools. Pick the right one:
+
+TOOL SELECTION
+- tavily_search (DEFAULT - start here): fast web search returning titles, URLs, and content snippets. Use for facts, news, current info, lookups. ALWAYS try this first.
+- tavily_research: deep multi-source synthesis for broad or complex questions. Slower; rate-limited (20/min). Escalate from tavily_search only when a single search is insufficient.
+- tavily_extract: read FULL content of specific URLs you ALREADY have. Takes a urls[] array - NOT a search query.
+- tavily_crawl: bulk-extract many pages from one website (configurable depth/breadth). Heavier than tavily_extract.
+- tavily_map: list a website's URLs (site structure) to target crawl/extract.
+
+HOW TOOLS COMBINE
+- Find then read: tavily_search to discover a source, then tavily_extract to read it in full.
+- Survey then mine: tavily_map to list a site's URLs, then tavily_crawl to pull them all.
+
+RETURN FORMAT (important)
+Every Tavily tool returns ONE markdown TEXT STRING. The whole result is plain text (titles, URLs, content). It is NOT a JSON object: there is no .results array, no .answer, and no .data property. Treat the return value itself as the text; do not index properties on it.
+
+All tools require the TAVILY_API_KEY environment variable. If a result says 'API key required', the key env var is missing.`,
       }
     );
 
@@ -167,7 +184,7 @@ class TavilyClient {
       const tools: Tool[] = [
         {
           name: "tavily_search",
-          description: "Search the web for current information on any topic. Use for news, facts, or data beyond your knowledge cutoff. Returns snippets and source URLs.",
+          description: "Search the web for current information on any topic - the DEFAULT tool for facts, news, and lookups (start here). Returns a single markdown text string of titles, URLs, and snippets; the return value is plain text, NOT a JSON object (no .results or .answer array).",
           inputSchema: {
             type: "object",
             properties: {
@@ -256,7 +273,7 @@ class TavilyClient {
         },
         {
           name: "tavily_extract",
-          description: "Extract content from URLs. Returns raw page content in markdown or text format.",
+          description: "Extract the FULL content of specific URLs you already have. Takes a urls[] array - NOT a search query; use tavily_search first to find URLs. Returns a single markdown/text string (not a JSON object).",
           inputSchema: {
             type: "object",
             properties: {
@@ -297,7 +314,7 @@ class TavilyClient {
         },
         {
           name: "tavily_crawl",
-          description: "Crawl a website starting from a URL. Extracts content from pages with configurable depth and breadth.",
+          description: "Crawl a website from a base URL, bulk-extracting content from many pages with configurable depth and breadth. Heavier than tavily_extract. Returns markdown text.",
           inputSchema: {
             type: "object",
             properties: {
@@ -367,7 +384,7 @@ class TavilyClient {
         },
         {
           name: "tavily_map",
-          description: "Map a website's structure. Returns a list of URLs found starting from the base URL.",
+          description: "Map a website's structure: returns the URLs found starting from a base URL. Use to discover targets for tavily_crawl or tavily_extract. Returns markdown text.",
           inputSchema: {
             type: "object",
             properties: {
@@ -420,7 +437,7 @@ class TavilyClient {
         },
         {
           name: "tavily_research",
-          description: "Perform comprehensive research on a given topic or question. Use this tool when you need to gather information from multiple sources to answer a question or complete a task. Returns a detailed response based on the research findings. Rate limit: 20 requests per minute.",
+          description: "Perform deep multi-source research on a topic, synthesizing across many sources. Escalate here from tavily_search only for broad or complex questions one search cannot answer. Rate-limited (20 requests/min). Returns a markdown text string.",
           inputSchema: {
             type: "object",
             properties: {
@@ -1016,23 +1033,23 @@ function listTools(): void {
   const tools = [
     {
       name: "tavily_search",
-      description: "A real-time web search tool powered by Tavily's AI engine. Features include customizable search depth (basic/advanced/fast/ultra-fast), domain filtering, time-based filtering, and support for both general and news-specific searches. Returns comprehensive results with titles, URLs, content snippets, and optional image results."
+      description: "Search the web for current information on any topic - the DEFAULT tool for facts, news, and lookups (start here). Returns a single markdown text string of titles, URLs, and snippets; the return value is plain text, NOT a JSON object (no .results or .answer array)."
     },
     {
       name: "tavily_extract",
-      description: "Extracts and processes content from specified URLs with advanced parsing capabilities. Supports both basic and advanced extraction modes, with the latter providing enhanced data retrieval including tables and embedded content. Ideal for data collection, content analysis, and research tasks."
+      description: "Extract the FULL content of specific URLs you already have. Takes a urls[] array - NOT a search query; use tavily_search first to find URLs. Returns a single markdown/text string (not a JSON object)."
     },
     {
       name: "tavily_crawl",
-      description: "A sophisticated web crawler that systematically explores websites starting from a base URL. Features include configurable depth and breadth limits, domain filtering, path pattern matching, and category-based filtering. Perfect for comprehensive site analysis, content discovery, and structured data collection."
+      description: "Crawl a website from a base URL, bulk-extracting content from many pages with configurable depth and breadth. Heavier than tavily_extract. Returns markdown text."
     },
     {
       name: "tavily_map",
-      description: "Creates detailed site maps by analyzing website structure and navigation paths. Offers configurable exploration depth, domain restrictions, and category filtering. Ideal for site audits, content organization analysis, and understanding website architecture and navigation patterns."
+      description: "Map a website's structure: returns the URLs found starting from a base URL. Use to discover targets for tavily_crawl or tavily_extract. Returns markdown text."
     },
     {
       name: "tavily_research",
-      description: "Performs comprehensive research on any topic or question by gathering information from multiple sources. Supports different research depths ('mini' for narrow tasks, 'pro' for broad research, 'auto' for automatic selection). Ideal for in-depth analysis, report generation, and answering complex questions requiring synthesis of multiple sources."
+      description: "Perform deep multi-source research on a topic, synthesizing across many sources. Escalate here from tavily_search only for broad or complex questions one search cannot answer. Rate-limited (20 requests/min). Returns a markdown text string."
     }
   ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,17 @@ const IS_KEYLESS = !API_KEY;
 const HUMAN_ID = process.env.TAVILY_HUMAN_ID;
 const SESSION_ID = randomUUID();
 
+/**
+ * When running without a TAVILY_API_KEY (keyless mode), append a note to the
+ * descriptions of tools that require a key, so agents don't attempt tools that
+ * can't run. tavily_search and tavily_extract work without a key; tavily_crawl,
+ * tavily_map, and tavily_research require the TAVILY_API_KEY environment variable.
+ */
+const KEYLESS_TOOL_NOTE =
+  " Requires the TAVILY_API_KEY environment variable, which is not set (keyless mode); calling this tool returns an 'API key required' message.";
+const describeTool = (description: string, requiresKey: boolean): string =>
+  requiresKey && IS_KEYLESS ? description + KEYLESS_TOOL_NOTE : description;
+
 
 interface TavilyResponse {
   // Response structure from Tavily API
@@ -107,7 +118,9 @@ HOW TOOLS COMBINE
 RETURN FORMAT (important)
 Every Tavily tool returns ONE markdown TEXT STRING. The whole result is plain text (titles, URLs, content). It is NOT a JSON object: there is no .results array, no .answer, and no .data property. Treat the return value itself as the text; do not index properties on it.
 
-All tools require the TAVILY_API_KEY environment variable. If a result says 'API key required', the key env var is missing.`,
+${IS_KEYLESS
+  ? `Running in KEYLESS mode (no TAVILY_API_KEY set): tavily_search and tavily_extract are available now. tavily_crawl, tavily_map, and tavily_research require the TAVILY_API_KEY environment variable and will return an 'API key required' message if called.`
+  : `tavily_search and tavily_extract also work in keyless mode; tavily_crawl, tavily_map, and tavily_research require the TAVILY_API_KEY environment variable (currently set). If a result says 'API key required', the key env var is missing.`}`,
       }
     );
 
@@ -314,7 +327,7 @@ All tools require the TAVILY_API_KEY environment variable. If a result says 'API
         },
         {
           name: "tavily_crawl",
-          description: "Crawl a website from a base URL, bulk-extracting content from many pages with configurable depth and breadth. Heavier than tavily_extract. Returns markdown text.",
+          description: describeTool("Crawl a website from a base URL, bulk-extracting content from many pages with configurable depth and breadth. Heavier than tavily_extract. Returns markdown text.", true),
           inputSchema: {
             type: "object",
             properties: {
@@ -384,7 +397,7 @@ All tools require the TAVILY_API_KEY environment variable. If a result says 'API
         },
         {
           name: "tavily_map",
-          description: "Map a website's structure: returns the URLs found starting from a base URL. Use to discover targets for tavily_crawl or tavily_extract. Returns markdown text.",
+          description: describeTool("Map a website's structure: returns the URLs found starting from a base URL. Use to discover targets for tavily_crawl or tavily_extract. Returns markdown text.", true),
           inputSchema: {
             type: "object",
             properties: {
@@ -437,7 +450,7 @@ All tools require the TAVILY_API_KEY environment variable. If a result says 'API
         },
         {
           name: "tavily_research",
-          description: "Perform deep multi-source research on a topic, synthesizing across many sources. Escalate here from tavily_search only for broad or complex questions one search cannot answer. Rate-limited (20 requests/min). Returns a markdown text string.",
+          description: describeTool("Perform deep multi-source research on a topic, synthesizing across many sources. Escalate here from tavily_search only for broad or complex questions one search cannot answer. Rate-limited (20 requests/min). Returns a markdown text string.", true),
           inputSchema: {
             type: "object",
             properties: {
@@ -1041,15 +1054,15 @@ function listTools(): void {
     },
     {
       name: "tavily_crawl",
-      description: "Crawl a website from a base URL, bulk-extracting content from many pages with configurable depth and breadth. Heavier than tavily_extract. Returns markdown text."
+      description: describeTool("Crawl a website from a base URL, bulk-extracting content from many pages with configurable depth and breadth. Heavier than tavily_extract. Returns markdown text.", true)
     },
     {
       name: "tavily_map",
-      description: "Map a website's structure: returns the URLs found starting from a base URL. Use to discover targets for tavily_crawl or tavily_extract. Returns markdown text."
+      description: describeTool("Map a website's structure: returns the URLs found starting from a base URL. Use to discover targets for tavily_crawl or tavily_extract. Returns markdown text.", true)
     },
     {
       name: "tavily_research",
-      description: "Perform deep multi-source research on a topic, synthesizing across many sources. Escalate here from tavily_search only for broad or complex questions one search cannot answer. Rate-limited (20 requests/min). Returns a markdown text string."
+      description: describeTool("Perform deep multi-source research on a topic, synthesizing across many sources. Escalate here from tavily_search only for broad or complex questions one search cannot answer. Rate-limited (20 requests/min). Returns a markdown text string.", true)
     }
   ];
 


### PR DESCRIPTION
Fixes #188.

`tavily-mcp` advertises five overlapping tools (`tavily_search`, `tavily_research`, `tavily_extract`, `tavily_crawl`, `tavily_map`) but provided **no server-level `instructions`** and only isolated per-tool descriptions. As a result, agents frequently pick the wrong tool or misuse them (e.g. calling `tavily_extract` as a search, passing a query instead of URLs), and `tools/list` gave no guidance on *which* tool to start with or *how they combine*. Issue #188 also flagged that in keyless mode the server advertises tools that cannot actually run.

## Changes

**1. Add a server-level `instructions` string** (the canonical MCP field) to the `Server` constructor's `ServerOptions`. Clients that surface `instructions` (Goose, Claude, Cursor) now get:
- a **tool-selection decision tree** (`tavily_search` is the default; escalate to `tavily_research` only for broad multi-source synthesis; `tavily_extract`/`crawl`/`map` are URL/site-scoped),
- **how the tools combine** (`search` -> `extract`; `map` -> `crawl`),
- the **return format**: every tool returns a single markdown text string, not a JSON object.

**2. Rewrite all five per-tool descriptions** (both the `ListTools` request handler and the `listTools()` helper, kept consistent) to state when to use each tool, how they combine, and that the return value is plain text.

**3. Surface keyless-mode limitations (second half of #188).** In keyless mode (no `TAVILY_API_KEY`), only `tavily_search` and `tavily_extract` work; `crawl`/`map`/`research` return an 'API key required' message at call time. Now reflected in the advertisement:
- The `instructions` API-key note is **mode-aware** (replacing the inaccurate 'All tools require TAVILY_API_KEY' line).
- A `describeTool()` helper appends a 'requires API key' note to the `crawl`/`map`/`research` descriptions **only when keyless**, in both the `ListTools` handler and the `listTools()` CLI helper. The advertised tool set is unchanged (annotation, not omission) for backwards compatibility.

## Compatibility

- Backwards compatible: `instructions` is an optional field; no tool name, schema, or API-call behavior changes.

## Verification

Verified end-to-end with an MCP stdio client against the built server (`0.2.21`), in **both** keyed and keyless modes:
- `initialize` returns `instructions` (mode-aware; the keyless branch lists which tools are available).
- `tools/list` returns the updated descriptions; `crawl`/`map`/`research` carry the keyless note only when `TAVILY_API_KEY` is unset; `search`/`extract` are always clean.
- Calling `crawl`/`map`/`research` while keyless returns the expected 'API key required' message (no errors).
- `tsc --noEmit` (strict) and `npm run build` pass; all 5 tools remain present with unchanged schemas.