### PR TITLE
fix: bump 3 vulnerable dependencies (high)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -678,9 +678,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -875,9 +875,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -939,9 +939,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary
Resolves all 8 open Dependabot alerts in this repo. All three packages are transitive dependencies whose parent ranges (`ajv`, `express-rate-limit`, `@modelcontextprotocol/sdk`) already permit the patched versions, so only `package-lock.json` changes — no `package.json` edits and no `overrides`.

- `fast-uri` 3.1.4 → 3.1.5 (high) — host confusion via backslash authority introducer (#89)
- `ip-address` 10.2.0 → 10.5.0 (high, medium, medium) — leading-zero octets decoded as decimal instead of octal, enabling SSRF/trust-boundary bypass (#88); CIDR suffix suppresses special-use classification (#86); misclassification of IPv4-mapped/NAT64 IPv6 addresses (#85)
- `hono` 4.12.27 → 4.13.3 (medium ×3, low) — `memo()` retains SSR output across requests (#92); Proxy Helper does not strip headers listed in `Connection` (#91); algorithmic complexity DoS in Language middleware (#90); ReDoS in CORS middleware (#87)

Supersedes the individual Dependabot PRs #199, #200 and #196, each at or below the versions landed here.

## Test plan
- [x] `npm ci` succeeds on a clean tree
- [x] `npm run build` (`tsc`) compiles with no errors
- [x] `npm audit` reports 0 vulnerabilities
- [x] Diff touches `package-lock.json` only, no source changes
- [ ] Confirm no breaking changes