### PR TITLE
docs: add FLUJO keyless remote client guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ After successful OAuth authentication, you can control which API key is used by 
 - If you have **both** a personal key and a team key named `mcp_auth_default`, the **personal key will be prioritized**.
 - If no `mcp_auth_default` key is set, the `default` key in your personal account will be used. If no `default` key is set, the first available key will be used.
 
+## Connect to FLUJO
+
+[FLUJO](https://github.com/mario-andreschak/FLUJO) can connect to the remote server using Tavily's [keyless access](https://docs.tavily.com/documentation/keyless). This mode needs no account or API key and is free but rate-limited.
+
+1. In FLUJO, open **Connected Apps**, select **Connect App**, and choose **I'm an expert**.
+2. Open **Configure & Test** and enter a **Server name**, such as `Tavily keyless`.
+3. Under **Third, define how to run your server**, select **Streamable HTTP** and set **Server URL** to `https://mcp.tavily.com/mcp/`.
+4. Under **Custom HTTP headers**, select **Add header**. Set **Header** to `X-Tavily-Access-Mode` and **Value** to `keyless`.
+5. Select **3) Test run**. After the connection test passes, select **Add server**.
+6. Open the new server card, select **Tools**, and choose `tavily_search`. Enter a query, set `max_results` to `1` for a small test, and select **Test tool**.
+
+Keyless access supports Search and Extract. Crawl, Map, and Research require an API key, even if they appear in the server's tool list.
+
 ## Local MCP 
 
 ### Prerequisites 🔧


### PR DESCRIPTION
FLUJO users can configure Tavily's documented public keyless header before connecting, then run a small search from the Tool Tester. This adds a 13-line README guide covering the current UI controls and links to the official keyless documentation.

Validation used the original prebuilt FLUJO 3.45.2 with a fresh data directory and Chromium profile on a cloud machine:

- Entered `X-Tavily-Access-Mode: keyless` through the visible custom-header form.
- Passed the Streamable HTTP handshake, saved the server, and verified the persisted header with a second connection test.
- Called `tavily_search` once with `max_results: 1`. It returned one official MCP documentation result and explicit `auth_mode: "keyless"`.
- `git diff --check` passes; only README.md changes. No runtime code or dependency changes.

The guide states the keyless tool and rate limits. Extraction, keyed access, OAuth, and the other tools were not tested. [Screenshots and the test receipt](https://github.com/flujo-app/flujo-mcp-client-validation/tree/main/tavily) document the actual result.

Prepared with AI assistance on behalf of the FLUJO project.

